### PR TITLE
refactor(provider): 初始化 stateListener 为 null

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -30,7 +30,7 @@ export const UpdateProvider = ({
   client = useRef(client).current;
   const { options } = client;
 
-  const stateListener = useRef<NativeEventSubscription>();
+  const stateListener = useRef<NativeEventSubscription|null>(null);
   const [updateInfo, setUpdateInfo] = useState<CheckResult>();
   const updateInfoRef = useRef(updateInfo);
   const [progress, setProgress] = useState<ProgressData>();


### PR DESCRIPTION
- useRef应该初始化null，将 stateListener 的初始值从 undefined 改为 null
- 以提高代码的健壮性和可读性