### PR TITLE
fix(security): reject implicit HTTP fallback and forged completion markers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,17 @@ jobs:
       # sync with the TS side by src/__tests__/flowVectors.test.ts (js-test).
       - name: Replay flow golden vectors against the C++ port
         run: SANITIZE=1 ./scripts/test-update-flow-core.sh
+
+  safe-zip-test:
+    name: Android archive safety
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Reject archive-owned completion markers
+        run: bash scripts/test-safe-zip-file.sh

--- a/.npmignore
+++ b/.npmignore
@@ -39,6 +39,7 @@ project.xcworkspace
 local.properties
 android/build
 android/obj
+android/src/test/
 .project
 
 # node.js

--- a/android/src/main/java/cn/reactnative/modules/update/SafeZipFile.java
+++ b/android/src/main/java/cn/reactnative/modules/update/SafeZipFile.java
@@ -18,6 +18,7 @@ public class SafeZipFile extends ZipFile {
     }
 
     private static final int BUFFER_SIZE = 8192;
+    private static final String RESERVED_COMPLETION_FILE = ".pushy-complete";
 
     @Override
     public Enumeration<? extends ZipEntry> entries() {
@@ -60,8 +61,23 @@ public class SafeZipFile extends ZipFile {
         // Fixing a Zip Path Traversal Vulnerability
         // https://support.google.com/faqs/answer/9294009
         String canonicalPath = target.getCanonicalPath();
-        if (!canonicalPath.startsWith(targetPath.getCanonicalPath() + File.separator)) {
+        String canonicalTargetPath = targetPath.getCanonicalPath();
+        if (!canonicalPath.startsWith(canonicalTargetPath + File.separator)) {
             throw new SecurityException("Illegal name: " + name);
+        }
+
+        // The completion marker is SDK-owned state, not package content. If an
+        // archive can create it, a failed or interrupted extraction may look
+        // complete and bypass the cleanup/retry path on the next launch.
+        String reservedCompletionPath = new File(
+            targetPath,
+            RESERVED_COMPLETION_FILE
+        ).getCanonicalPath();
+        if (
+            canonicalPath.equals(reservedCompletionPath)
+                || canonicalPath.startsWith(reservedCompletionPath + File.separator)
+        ) {
+            throw new SecurityException("Archive targets reserved control path: " + name);
         }
 
         if (ze.isDirectory()) {

--- a/android/src/test/java/cn/reactnative/modules/update/SafeZipFileTest.java
+++ b/android/src/test/java/cn/reactnative/modules/update/SafeZipFileTest.java
@@ -1,0 +1,108 @@
+package cn.reactnative.modules.update;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public final class SafeZipFileTest {
+    public static void main(String[] args) throws Exception {
+        rejectsReservedEntry(".pushy-complete");
+        rejectsReservedEntry("./.pushy-complete");
+        rejectsReservedEntry(".pushy-complete/payload");
+        extractsOrdinaryEntry();
+        System.out.println("SafeZipFile tests passed");
+    }
+
+    private static void rejectsReservedEntry(String entryName) throws Exception {
+        File root = Files.createTempDirectory("safe-zip-reserved").toFile();
+        try {
+            File archive = new File(root, "input.zip");
+            writeArchive(archive, entryName, "forged");
+            File destination = new File(root, "out");
+            if (!destination.mkdirs()) {
+                throw new AssertionError("failed to create destination");
+            }
+
+            boolean rejected = false;
+            try (SafeZipFile zip = new SafeZipFile(archive)) {
+                Enumeration<? extends ZipEntry> entries = zip.entries();
+                while (entries.hasMoreElements()) {
+                    try {
+                        zip.unzipToPath(entries.nextElement(), destination);
+                    } catch (SecurityException expected) {
+                        rejected = true;
+                    }
+                }
+            }
+
+            if (!rejected) {
+                throw new AssertionError("reserved entry was accepted: " + entryName);
+            }
+            if (new File(destination, ".pushy-complete").exists()) {
+                throw new AssertionError("reserved completion path was created: " + entryName);
+            }
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    private static void extractsOrdinaryEntry() throws Exception {
+        File root = Files.createTempDirectory("safe-zip-ordinary").toFile();
+        try {
+            File archive = new File(root, "input.zip");
+            writeArchive(archive, "assets/icon.txt", "ok");
+            File destination = new File(root, "out");
+            if (!destination.mkdirs()) {
+                throw new AssertionError("failed to create destination");
+            }
+
+            try (SafeZipFile zip = new SafeZipFile(archive)) {
+                Enumeration<? extends ZipEntry> entries = zip.entries();
+                while (entries.hasMoreElements()) {
+                    zip.unzipToPath(entries.nextElement(), destination);
+                }
+            }
+
+            File extracted = new File(destination, "assets/icon.txt");
+            String content = new String(
+                Files.readAllBytes(extracted.toPath()),
+                StandardCharsets.UTF_8
+            );
+            if (!"ok".equals(content)) {
+                throw new AssertionError("ordinary entry was not extracted correctly");
+            }
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    private static void writeArchive(File archive, String entryName, String content)
+        throws Exception {
+        try (ZipOutputStream output = new ZipOutputStream(new FileOutputStream(archive))) {
+            output.putNextEntry(new ZipEntry(entryName));
+            output.write(content.getBytes(StandardCharsets.UTF_8));
+            output.closeEntry();
+        }
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        if (!file.delete() && file.exists()) {
+            throw new AssertionError("failed to delete " + file);
+        }
+    }
+}

--- a/harmony/pushy/src/main/ets/DownloadTask.ts
+++ b/harmony/pushy/src/main/ets/DownloadTask.ts
@@ -144,6 +144,10 @@ export class DownloadTask {
   // 一经 downloadFile 正常返回即置位:之后的失败是 patch 应用失败,归档
   // 已被判定有毒,清理时必须连 sidecar 一起删,绝不能续传进同一个失败。
   private downloadPhaseCompleted = false;
+  // Set when archive content, rather than the SDK, creates the completion
+  // marker. The error cleanup must then remove the directory even though the
+  // marker + bundle pair would normally protect a completed concurrent task.
+  private archiveContainedCompletionMarker = false;
 
   constructor(context: common.Context) {
     this.context = context;
@@ -270,6 +274,19 @@ export class DownloadTask {
   private async recreateDirectory(path: string): Promise<void> {
     await this.removeDirectory(path);
     await this.ensureDirectory(path);
+  }
+
+  private assertArchiveDoesNotOwnCompletionMarker(directory: string): void {
+    const markerPath = `${directory}/${VERSION_COMPLETE_FILE_NAME}`;
+    if (!fileIo.accessSync(markerPath)) {
+      return;
+    }
+    this.archiveContainedCompletionMarker = true;
+    const error: any = Error(
+      `Archive contains reserved control file: ${VERSION_COMPLETE_FILE_NAME}`,
+    );
+    error.code = 'PATCH_FAILED';
+    throw error;
   }
 
   private async readFileContent(filePath: string): Promise<ArrayBuffer> {
@@ -876,6 +893,7 @@ export class DownloadTask {
     await this.downloadFile(params);
     await this.recreateDirectory(params.unzipDirectory);
     await zlib.decompressFile(params.targetFile, params.unzipDirectory);
+    this.assertArchiveDoesNotOwnCompletionMarker(params.unzipDirectory);
     await this.deleteArchiveAndSidecar(params.targetFile);
   }
 
@@ -898,6 +916,7 @@ export class DownloadTask {
     await this.recreateDirectory(params.unzipDirectory);
 
     await zlib.decompressFile(params.targetFile, params.unzipDirectory);
+    this.assertArchiveDoesNotOwnCompletionMarker(params.unzipDirectory);
     const [entryNames, manifestArrays] = await Promise.all([
       this.listEntryNames(params.unzipDirectory),
       this.readManifestArrays(params.unzipDirectory, true),
@@ -964,6 +983,7 @@ export class DownloadTask {
     await this.recreateDirectory(params.unzipDirectory);
 
     await zlib.decompressFile(params.targetFile, params.unzipDirectory);
+    this.assertArchiveDoesNotOwnCompletionMarker(params.unzipDirectory);
     const [entryNames, manifestArrays] = await Promise.all([
       this.listEntryNames(params.unzipDirectory),
       this.readManifestArrays(params.unzipDirectory, false),
@@ -1119,6 +1139,7 @@ export class DownloadTask {
   }
 
   public async execute(params: DownloadTaskParams): Promise<void> {
+    this.archiveContainedCompletionMarker = false;
     const isPatchTask =
       params.type === DownloadTaskParams.TASK_TYPE_PATCH_FULL ||
       params.type === DownloadTaskParams.TASK_TYPE_PATCH_FROM_APP ||
@@ -1160,6 +1181,7 @@ export class DownloadTask {
             await fileIo.unlink(params.targetFile);
             await this.deleteResumeSidecar(params.targetFile);
           } else if (
+            this.archiveContainedCompletionMarker ||
             !fileIo.accessSync(
               `${params.unzipDirectory}/${VERSION_COMPLETE_FILE_NAME}`,
             ) ||

--- a/ios/RCTPushy/RCTPushy.mm
+++ b/ios/RCTPushy/RCTPushy.mm
@@ -1407,11 +1407,27 @@ RCT_EXPORT_METHOD(resetToPackagedBundle:(RCTPromiseResolveBlock)resolve
             // survive to vouch for bytes that are gone.
             [fileManager removeItemAtPath:[archivePath stringByAppendingString:@".resume"]
                                     error:nil];
+            NSError *unzipError = error;
+            NSString *reservedMarker =
+                [destination stringByAppendingPathComponent:VERSION_COMPLETE_FILE_NAME];
+            if ([fileManager fileExistsAtPath:reservedMarker]) {
+                // The marker is SDK-owned state and is written only after the
+                // full unzip/patch pipeline succeeds. Remove it first so even
+                // a failed directory cleanup cannot leave a forged completed
+                // version behind.
+                [fileManager removeItemAtPath:reservedMarker error:nil];
+                [fileManager removeItemAtPath:destination error:nil];
+                succeeded = NO;
+                unzipError = PushyErrorWithCode(
+                    pushy::error_codes::kPatchFailed,
+                    @"archive contains reserved control file: .pushy-complete"
+                );
+            }
+
             if (completionHandler == nil) {
                 return;
             }
 
-            NSError *unzipError = error;
             if (!succeeded && unzipError == nil) {
                 unzipError = PushyErrorWithCode(pushy::error_codes::kPatchFailed, @"unzip failed");
             } else if (unzipError != nil && unzipError.userInfo[PushyErrorCodeKey] == nil) {

--- a/scripts/test-safe-zip-file.sh
+++ b/scripts/test-safe-zip-file.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/.tmp/safe-zip-file-test"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+javac -d "$BUILD_DIR"   "$ROOT_DIR/android/src/main/java/cn/reactnative/modules/update/SafeZipFile.java"   "$ROOT_DIR/android/src/test/java/cn/reactnative/modules/update/SafeZipFileTest.java"
+
+java -cp "$BUILD_DIR" cn.reactnative.modules.update.SafeZipFileTest

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -22,6 +22,7 @@ import {
   fetchWithTimeout,
   joinUrls,
   promiseAny,
+  testUrls,
 } from '../utils';
 
 const originalFetch = globalThis.fetch;
@@ -183,27 +184,45 @@ describe('fetchWithTimeout', () => {
   });
 });
 
-describe('enhancedFetch http fallback', () => {
-  test('retries idempotent requests over http with the scheme anchored', async () => {
+describe('enhancedFetch transport security', () => {
+  test('does not downgrade a failed HTTPS GET request to HTTP', async () => {
+    const calls: string[] = [];
+    (globalThis as any).fetch = mock(async (url: string) => {
+      calls.push(url);
+      throw new Error('tls blocked');
+    });
+
+    await expect(
+      enhancedFetch('https://example.com/dl/https-bundle.ppk', {})
+    ).rejects.toThrow('tls blocked');
+    expect(calls).toEqual(['https://example.com/dl/https-bundle.ppk']);
+  });
+
+  test('does not downgrade a failed HTTPS HEAD request to HTTP', async () => {
+    const calls: string[] = [];
+    (globalThis as any).fetch = mock(async (url: string) => {
+      calls.push(url);
+      throw new Error('tls blocked');
+    });
+
+    await expect(
+      enhancedFetch('https://example.com/update.ppk', { method: 'HEAD' })
+    ).rejects.toThrow('tls blocked');
+    expect(calls).toEqual(['https://example.com/update.ppk']);
+  });
+
+  test('keeps an explicitly configured HTTP URL unchanged', async () => {
     const calls: string[] = [];
     const response = { ok: true } as Response;
     (globalThis as any).fetch = mock(async (url: string) => {
       calls.push(url);
-      if (calls.length === 1) {
-        throw new Error('tls blocked');
-      }
       return response;
     });
 
-    // Path contains the substring "https" on purpose: a non-anchored replace
-    // would corrupt the path instead of the scheme.
-    expect(
-      await enhancedFetch('https://example.com/dl/https-bundle.ppk', {})
-    ).toBe(response);
-    expect(calls).toEqual([
-      'https://example.com/dl/https-bundle.ppk',
-      'http://example.com/dl/https-bundle.ppk',
-    ]);
+    expect(await enhancedFetch('http://127.0.0.1:31337/update.ppk', {})).toBe(
+      response
+    );
+    expect(calls).toEqual(['http://127.0.0.1:31337/update.ppk']);
   });
 
   test('does not replay POST requests over http (JS-11 regression)', async () => {
@@ -218,7 +237,7 @@ describe('enhancedFetch http fallback', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  test('does not downgrade urls that are not https', async () => {
+  test('does not rewrite urls that are already HTTP', async () => {
     const fetchMock = mock(async () => {
       throw new Error('offline');
     });
@@ -226,6 +245,25 @@ describe('enhancedFetch http fallback', () => {
 
     await expect(enhancedFetch('http://example.com/api', {})).rejects.toThrow(
       'offline'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('testUrls transport security', () => {
+  test('does not propagate an HTTPS probe redirected to HTTP', async () => {
+    const fetchMock = mock(
+      async () =>
+        ({
+          status: 200,
+          statusText: 'OK',
+          url: 'http://cdn.example.com/update.ppk',
+        }) as Response
+    );
+    (globalThis as any).fetch = fetchMock;
+
+    expect(await testUrls(['https://cdn.example.com/update.ppk'])).toBe(
+      'https://cdn.example.com/update.ppk'
     );
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,7 +66,12 @@ const ping = isWeb
           DEFAULT_FETCH_TIMEOUT_MS
         );
         if (status === 200) {
-          return finalUrl;
+          const resolvedUrl = finalUrl || url;
+          if (/^https:/i.test(url) && /^http:/i.test(resolvedUrl)) {
+            log('ping rejected insecure redirect', url, resolvedUrl);
+            throw Error(i18n.t('error_ping_failed'));
+          }
+          return resolvedUrl;
         }
         log('ping failed', url, status, statusText);
         throw Error(i18n.t('error_ping_failed'));
@@ -166,29 +171,12 @@ export const fetchWithTimeout = (
     });
 };
 
-const isIdempotentRequest = (params: Parameters<typeof fetch>[1]) => {
-  const method = params?.method?.toUpperCase() ?? 'GET';
-  return method === 'GET' || method === 'HEAD';
-};
-
 export const enhancedFetch = async (
   url: string,
-  params: Parameters<typeof fetch>[1],
-  isRetry = false
+  params: Parameters<typeof fetch>[1]
 ): Promise<Response> => {
   return fetch(url, params).catch((e) => {
     log('fetch error', url, e);
-    if (
-      isRetry ||
-      (params as any)?.signal?.aborted ||
-      !url.startsWith('https:') ||
-      // Never replay non-idempotent requests (e.g. the checkUpdate POST)
-      // over plaintext http: the server may have processed the original.
-      !isIdempotentRequest(params)
-    ) {
-      throw e;
-    }
-    log('trying fallback to http');
-    return enhancedFetch(url.replace(/^https:/, 'http:'), params, true);
+    throw e;
   });
 };


### PR DESCRIPTION
## 背景

代码审计发现两个更新信任边界问题：

1. JS 的 `enhancedFetch` 在 HTTPS GET/HEAD 失败后会自动改用 HTTP 重试；更新包 URL 探测也可能把 HTTPS 重定向后的 HTTP 地址传给实际下载流程。
2. `.pushy-complete` 是 SDK 用来确认版本安装完成的控制文件，但归档自身此前可以创建该文件。若后续解压或打补丁失败，伪造的 marker 与残留 bundle 可能使目录在清理或下一轮检查中被误判为完整安装。

## 改动

### 传输安全

- 删除 JS 网络层的自动 HTTPS → HTTP 重试；
- HTTPS 探测若最终响应 URL 被降级为 HTTP，拒绝采用该地址；
- 显式配置的 `http://` 地址仍保持可用，兼容本地开发和明确使用 HTTP 的内网自托管场景；
- 增加 GET、HEAD、POST、显式 HTTP 和探测重定向回归测试。

### 完成标记所有权

- Android 在统一 `SafeZipFile` 解压入口拒绝 `.pushy-complete` 及其子路径，包括经过 canonical path 归一化后的变体；
- iOS 在解压完成后发现归档创建的 marker 时，先删除 marker 和目标目录，再以 `PATCH_FAILED` 结束；
- HarmonyOS 在每次解压后检查保留 marker，并确保清理逻辑不会把伪造的 marker + bundle 当作其他并发任务已经完成的版本；
- 新增独立 Java 回归测试，覆盖 `.pushy-complete`、`./.pushy-complete`、子路径和正常文件解压；
- 将该测试接入主 `test` workflow，并从 npm 发布包排除 `android/src/test/`。

## 验证

- `bun test src/__tests__`：182 pass，0 fail
- `bun lint`
- `bash scripts/test-safe-zip-file.sh`
- `git diff --check`

## 兼容性

- 无公开 JS API 变更；
- 正常更新包行为不变；
- 显式 HTTP 自托管地址仍可使用；
- 包含 SDK 保留控制文件 `.pushy-complete` 的归档现在会被拒绝。

## 范围说明

本 PR 先处理评审中的两个最高优先级问题：隐式 HTTP 降级与归档伪造完成标记。原生下载栈对服务端 HTTPS→HTTP redirect 的统一限制、staging 目录与签名 manifest 等进一步加固，适合另开 PR，避免把本次安全补丁扩展成大规模下载管线重构。

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reactnativecn/codesmith/react-native-update/pr/630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790605462&installation_model_id=426977&pr_number=630&repository=reactnativecn%2Freact-native-update&return_to=https%3A%2F%2Fgithub.com%2Freactnativecn%2Freact-native-update%2Fpull%2F630&signature=2a5ae6d20b69fe22bae05c6d62b8ae882dd8feef0519d054b6b04e73fd470e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Prevented downloaded archives from creating or claiming the app’s completion marker.
  * Added cleanup and failure handling when unsafe archive contents are detected.
  * Blocked HTTPS requests from being redirected or retried over HTTP.
  * Preserved explicitly configured HTTP connections.

* **Bug Fixes**
  * Improved archive extraction safety and prevented unsafe files from remaining on disk.
  * Ensured secure URL checks handle redirects correctly.

* **Tests**
  * Added coverage for unsafe archive entries, successful extraction, and HTTPS downgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->