### PR TITLE
chore: release 10.56.0

### DIFF
--- a/android/proguard.pro
+++ b/android/proguard.pro
@@ -46,7 +46,14 @@
     *** useDevSupport;
     *** mReactHostDelegate;
     *** reactHostDelegate;
-    void reload(java.lang.String);
+    *** reload(java.lang.String);
+}
+# reload(String) returns TaskInterface<Void> (not void) and is looked up on
+# the runtime class of whatever ReactHost the app provides; the `***` return
+# type is what makes the rule match — verified against an R8-minified
+# RN 0.85 build, where `void reload(...)` silently kept nothing.
+-keepclassmembers class * implements com.facebook.react.ReactHost {
+    *** reload(java.lang.String);
 }
 -keepclassmembers class * implements com.facebook.react.runtime.ReactHostDelegate {
     *** jsBundleLoader;

--- a/harmony/pushy/oh-package.json5
+++ b/harmony/pushy/oh-package.json5
@@ -7,7 +7,7 @@
   name: 'pushy',
   description: '',
   main: 'index.ets',
-  version: '10.55.1',
+  version: '10.56.0',
   dependencies: {
     '@rnoh/react-native-openharmony': '>=0.72.96',
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-update",
-  "version": "10.55.1",
+  "version": "10.56.0",
   "description": "react-native hot update",
   "main": "src/index",
   "types": "src/index.ts",

--- a/scripts/check-packlist.js
+++ b/scripts/check-packlist.js
@@ -67,7 +67,11 @@ const json = execFileSync(
   ['pack', '--dry-run', '--json', '--ignore-scripts'],
   { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
 );
-const files = JSON.parse(json)[0].files.map((f) => f.path);
+// npm <= 11 prints an array of packed tarballs; npm 12 prints an object
+// keyed by package name. Accept both.
+const parsed = JSON.parse(json);
+const packed = Array.isArray(parsed) ? parsed[0] : Object.values(parsed)[0];
+const files = packed.files.map((f) => f.path);
 const set = new Set(files);
 const problems = [];
 


### PR DESCRIPTION
## Summary

Release prep for 10.56.0 (the audit PRs #635 / #637).

- **ProGuard fix (release blocker found during verification).** The audit's narrowed rules used `void reload(java.lang.String)` for `ReactHostImpl`, but RN's `reload` returns `TaskInterface<Void>`, so the rule matched nothing. In an R8-minified new-architecture build (RN 0.85, `minifyEnabled true`) the method was renamed and `restartApp` would reject `RESTART_FAILED`. The rule now uses a `***` return type and also covers every `ReactHost` implementation.
- **Verification of the narrowed rules.** Built the example app with `minifyEnabled true` and inspected the R8 output (dexdump + mapping): the three JNI result classes keep their no-arg constructor and every field, all 11 native methods keep their names, and every reflection target (`getReactDelegate`, `ReactDelegate.reactHost`, `ReactHostImpl.useDevSupport` / `reactHostDelegate` / `reload`, `DefaultReactHostDelegate.jsBundleLoader`, `MainApplication.getReactHost`, `BuildConfig.IS_NEW_ARCHITECTURE_ENABLED`, `ReactContext.hasActiveReactInstance`) is present. `ReactNativeHost` / `ReactInstanceManager` are empty shells in that app because the new-architecture template never instantiates them; those paths are old-arch only and guarded.
- `check-packlist.js` accepts npm 12's object-shaped `pack --json` output.
- Version bump to 10.56.0 in `package.json` and `harmony/pushy/oh-package.json5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149oHt3QpNA3XNocSBVFNCh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reactnativecn/codesmith/react-native-update/pr/638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791099935&installation_model_id=426977&pr_number=638&repository=reactnativecn%2Freact-native-update&return_to=https%3A%2F%2Fgithub.com%2Freactnativecn%2Freact-native-update%2Fpull%2F638&signature=ce854bc1dc0f6d1bb264246ff49b7a8ad3f8b991f06efc031d7bb11387de3698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android release builds so reload functionality remains available across supported runtime implementations.
  * Improved package validation compatibility with output formats used by newer npm versions.

* **Release Updates**
  * Updated the package version to 10.56.0 across the project and Harmony package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->